### PR TITLE
Replaced mark-active by (use-region-p)

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -98,7 +98,7 @@ the region or the current line (if the mark is not active)."
 (defun smart-tab-default ()
   "Indents region if mark is active, or current line otherwise."
   (interactive)
-  (if mark-active
+  (if (use-region-p)
       (indent-region (region-beginning)
                      (region-end))
     (indent-for-tab-command)))
@@ -107,7 +107,7 @@ the region or the current line (if the mark is not active)."
   "If PREFIX is \\[universal-argument] or the mark is active, do not expand.
 Otherwise, uses `hippie-expand' or `dabbrev-expand' to expand the text at point.."
   (unless (or (consp prefix)
-              mark-active)
+              (use-region-p))
     (looking-at "\\_>")))
 
 ;;;###autoload


### PR DESCRIPTION
Hi,

I just replaced mark-active by (use-region-p) in smart-tab: it works better with modes like vimpulse, that activate the mark all the time, but don't use it most of the time.

And a small bug fix for prefix argument.

Cheers,
Sébastien Roccaserra.
