### PR TITLE
Tweak to auto-complete integration

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -92,7 +92,7 @@ If current major mode is not found in this alist, fall back to
         (if (and (not (minibufferp))
                  (memq 'auto-complete-mode minor-mode-list)
                  auto-complete-mode)
-            (auto-complete)
+            (ac-start :force-init t)
           (if smart-tab-using-hippie-expand
               (hippie-expand nil)
             (dabbrev-expand nil)))


### PR DESCRIPTION
When the word at point is a unique expansion, calling `auto-complete` does nothing; with this patch, smart-tab instead calls `ac-start` directly, which has the effect that auto-complete's doc tooltip will be displayed for the word at point. This is a handy feature, and one which auto-complete users are accustomed to when using that package's default behavior.
-Steve
