### PR TITLE
remove .gitignore; ignored *.elc in global ignore file instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-smart-tab.elc


### PR DESCRIPTION
Since you likely never want to track byte-compiled files you should globally ignore them:

Add the ignore rules to `/etc/gitignore` and the following to `/etc/gitconfig`:

```
[core]
        excludesfile = /etc/gitignore
```

By the way do you have Daniels blessing as the new maintainer? I am currently mirroring your repository on the Emacsmirror. Also could you please make a new release... it has been a while.
