### PR TITLE
Autoload global-smart-tab-mode.

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -184,6 +184,7 @@ Null prefix argument turns off the mode."
                   (member major-mode smart-tab-disabled-major-modes))
           (smart-tab-mode-off)))))
 
+;;;###autoload
 (define-globalized-minor-mode global-smart-tab-mode
   smart-tab-mode
   smart-tab-mode-on


### PR DESCRIPTION
It's common in elisp packages to autoload the primary commands so users
have them available immediately after install, and don't need to add
`(require 'smart-tab)` in their configuration. I'd like to be able to
do the same with smart-tab.