### PR TITLE
Support company-mode and complete at end of line

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -155,7 +155,7 @@ active, or PREFIX is \\[universal-argument], then `smart-tab'
 will indent the region or the current line (if the mark is not
 active)."
   (interactive "P")
-  (if (smart-tab-must-expand prefix)
+  (if (or (smart-tab-must-expand prefix) (eolp))
       (smart-tab-call-completion-function)
     (smart-tab-default)))
 

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -109,10 +109,12 @@ If current major mode is not found in this alist, fall back to
     (cond
      (completion-function
       (funcall completion-function))
-     ((and (not (minibufferp))
-           (memq 'auto-complete-mode minor-mode-list)
-           (boundp' auto-complete-mode)
-           auto-complete-mode)
+     ((minibufferp)
+      (minibuffer-complete))
+     ((and
+       (memq 'auto-complete-mode minor-mode-list)
+       (boundp' auto-complete-mode)
+       auto-complete-mode)
       (smart-tab-funcall 'ac-start :force-init t))
      (t
       (dabbrev-expand)))))

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -58,7 +58,8 @@
 
 (eval-when-compile
   ;; Forward declaration, does not define variable
-  (defvar auto-complete-mode))
+  (defvar auto-complete-mode)
+  (defvar company-mode))
 
 (defgroup smart-tab nil
   "Options for `smart-tab-mode'."
@@ -111,6 +112,8 @@ If current major mode is not found in this alist, fall back to
       (funcall completion-function))
      ((minibufferp)
       (minibuffer-complete))
+     (company-mode
+      (company-complete))
      ((and
        (memq 'auto-complete-mode minor-mode-list)
        (boundp' auto-complete-mode)

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -106,16 +106,16 @@ If current major mode is not found in this alist, fall back to
       (message "complete"))
   (let ((completion-function
          (cdr (assq major-mode smart-tab-completion-functions-alist))))
-    (if (null completion-function)
-        (if (and (not (minibufferp))
-                 (memq 'auto-complete-mode minor-mode-list)
-                 (boundp' auto-complete-mode)
-                 auto-complete-mode)
-            (smart-tab-funcall 'ac-start :force-init t)
-          (if smart-tab-using-hippie-expand
-              (hippie-expand nil)
-            (dabbrev-expand nil)))
-      (funcall completion-function))))
+    (cond
+     (completion-function
+      (funcall completion-function))
+     ((and (not (minibufferp))
+           (memq 'auto-complete-mode minor-mode-list)
+           (boundp' auto-complete-mode)
+           auto-complete-mode)
+      (smart-tab-funcall 'ac-start :force-init t))
+     (t
+      (dabbrev-expand)))))
 
 (defun smart-tab-must-expand (&optional prefix)
   "If PREFIX is \\[universal-argument] or the mark is active, do not expand.


### PR DESCRIPTION
Hi there!

Thanks for this great utility. I've made two small changes, I hope you like them!

Firstly, I've added support for [company-mode](http://company-mode.github.io/), so smart-tab will use that if enabled.

Secondly, I've changed the end-of-line behaviour to be completion. As a result, when you're typing `someObj.|` then you can complete method names!

Let me know what you think :)
