### PR TITLE
Fall back to major mode's tab if unable to expand

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -133,7 +133,16 @@ the text at point."
   (if (use-region-p)
       (indent-region (region-beginning)
                      (region-end))
-    (indent-for-tab-command)))
+    (let* ((smart-tab-mode nil)
+           (global-smart-tab-mode nil)
+           (ev last-command-event)
+           (triggering-key (cl-case (type-of ev)
+                             (integer (char-to-string ev))
+                             (symbol (vector ev))))
+           (original-func (or (key-binding triggering-key)
+                              'indent-for-tab-command)))
+      (call-interactively original-func))))
+
 
 ;;;###autoload
 (defun smart-tab (&optional prefix)


### PR DESCRIPTION
In modes where tab is associated to something other than indenting,
smart-tab breaks the behavior, unless the user manually disables it
through `smart-tab-disabled-major-modes'.

If no completion is available, make `smart-tab-default' fall back to tab
behavior as defined in major mode or, if none is defined,
`indent-for-tab-command'.

Possibly makes `smart-tab-disabled-major-modes' superfluous.

Motivated by smart-tab breaking markdown-mode. Re-implements
7c80c79 though a bit more elegantly.