### PR TITLE
Fall back to major mode's tab if unable to expand

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -133,7 +133,16 @@ the text at point."
   (if (use-region-p)
       (indent-region (region-beginning)
                      (region-end))
-    (indent-for-tab-command)))
+    (let* ((smart-tab-mode nil)
+           (global-smart-tab-mode nil)
+           (ev last-command-event)
+           (triggering-key (cl-case (type-of ev)
+                             (integer (char-to-string ev))
+                             (symbol (vector ev))))
+           (original-func (or (key-binding triggering-key)
+                              'indent-for-tab-command)))
+      (call-interactively original-func))))
+
 
 ;;;###autoload
 (defun smart-tab (&optional prefix)
@@ -151,7 +160,7 @@ will indent the region or the current line (if the mark is not
 active)."
   (interactive "P")
   (if (smart-tab-must-expand prefix)
-      (smart-tab-call-completion-function)
+      (or (smart-tab-call-completion-function) (smart-tab-default))
     (smart-tab-default)))
 
 ;;;###autoload

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -164,9 +164,6 @@ active)."
    ((use-region-p)
     (indent-region (region-beginning)
                    (region-end)))
-   ;; If we decide we should try expansion but then no expansion is
-   ;; available, fall back to default behavior. (Avoids hitting TAB at
-   ;; the end of a line without visible effect.)
    ((smart-tab-must-expand prefix)
     (smart-tab-call-completion-function))
    (t

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -130,18 +130,17 @@ the text at point."
   (interactive)
   (if smart-tab-debug
       (message "default"))
-  (if (use-region-p)
-      (indent-region (region-beginning)
-                     (region-end))
-    (let* ((smart-tab-mode nil)
-           (global-smart-tab-mode nil)
-           (ev last-command-event)
-           (triggering-key (cl-case (type-of ev)
-                             (integer (char-to-string ev))
-                             (symbol (vector ev))))
-           (original-func (or (key-binding triggering-key)
-                              'indent-for-tab-command)))
-      (call-interactively original-func))))
+  (let* ((smart-tab-mode nil)
+         (global-smart-tab-mode nil)
+         (ev last-command-event)
+         (triggering-key (cl-case (type-of ev)
+                           (integer (char-to-string ev))
+                           (symbol (vector ev))))
+         (original-func (or (key-binding triggering-key)
+                            (key-binding (lookup-key local-function-key-map
+                                                     triggering-key))
+                            'indent-for-tab-command)))
+    (call-interactively original-func)))
 
 
 ;;;###autoload
@@ -159,9 +158,17 @@ active, or PREFIX is \\[universal-argument], then `smart-tab'
 will indent the region or the current line (if the mark is not
 active)."
   (interactive "P")
-  (if (smart-tab-must-expand prefix)
-      (or (smart-tab-call-completion-function) (smart-tab-default))
-    (smart-tab-default)))
+  (cond
+   (buffer-read-only
+    (smart-tab-default))
+   ((use-region-p)
+    (indent-region (region-beginning)
+                   (region-end)))
+   ((smart-tab-must-expand prefix)
+    (or (smart-tab-call-completion-function)
+        (smart-tab-default)))
+   (t
+    (smart-tab-default))))
 
 ;;;###autoload
 (defun smart-tab-mode-on ()

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -164,6 +164,9 @@ active)."
    ((use-region-p)
     (indent-region (region-beginning)
                    (region-end)))
+   ;; If we decide we should try expansion but then no expansion is
+   ;; available, fall back to default behavior. (Avoids hitting TAB at
+   ;; the end of a line without visible effect.)
    ((smart-tab-must-expand prefix)
     (or (smart-tab-call-completion-function)
         (smart-tab-default)))

--- a/smart-tab.el
+++ b/smart-tab.el
@@ -168,8 +168,7 @@ active)."
    ;; available, fall back to default behavior. (Avoids hitting TAB at
    ;; the end of a line without visible effect.)
    ((smart-tab-must-expand prefix)
-    (or (smart-tab-call-completion-function)
-        (smart-tab-default)))
+    (smart-tab-call-completion-function))
    (t
     (smart-tab-default))))
 


### PR DESCRIPTION
In modes where tab is associated to something other than indenting,
smart-tab breaks the behavior, unless the user manually disables it
through `smart-tab-disabled-major-modes`.

If no completion is available, make `smart-tab-default` fall back to tab
behavior as defined in major mode or, if none is defined,
`indent-for-tab-command`.

Possibly makes `smart-tab-disabled-major-modes` superfluous. Motivated
by smart-tab breaking markdown-mode. Re-implements 7c80c79, though a bit
more elegantly.