### PR TITLE
call ac-start only when auto-complete-mode is not nil

### DIFF
--- a/smart-tab.el
+++ b/smart-tab.el
@@ -130,6 +130,7 @@ Use one of these default methods to attempt completion."
      ((and (not (minibufferp))
            (memq 'auto-complete-mode minor-mode-list)
            (boundp 'auto-complete-mode)
+	   auto-complete-mode
            (fboundp 'ac-start))
       (ac-start :force-init t nil))
 


### PR DESCRIPTION
As the title said, do not call acc-start when auto-complete-mode is disabled in buffer